### PR TITLE
Complete type hints for public API

### DIFF
--- a/pysource_minimize/_minimize.py
+++ b/pysource_minimize/_minimize.py
@@ -57,7 +57,7 @@ def minimize(
     checker: Callable[[str], bool],
     *,
     progress_callback: Callable[[int, int], object] = lambda current, total: None,
-    retries: int = 1
+    retries: int = 1,
 ) -> str:
     """
     minimzes the source code

--- a/pysource_minimize/_minimize.py
+++ b/pysource_minimize/_minimize.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 import warnings
 from collections.abc import Callable

--- a/pysource_minimize/_minimize.py
+++ b/pysource_minimize/_minimize.py
@@ -1,5 +1,6 @@
 import ast
 import warnings
+from collections.abc import Callable
 
 from ._minimize_base import equal_ast
 from ._minimize_structure import MinimizeStructure
@@ -52,7 +53,11 @@ def minimize_ast(
 
 
 def minimize(
-    source: str, checker, *, progress_callback=lambda current, total: None, retries=1
+    source: str,
+    checker: Callable[[str], bool],
+    *,
+    progress_callback: Callable[[int, int], object] = lambda current, total: None,
+    retries: int = 1
 ) -> str:
     """
     minimzes the source code


### PR DESCRIPTION
This PR fills in type annotations for the parameters in `minimize()` that are currently unannotated.

If you're not all that interested in typing then obviously feel free to close this :-) but it would be a minor quality-of-life improvement for me -- currently pyright `--strict` complains whenever I use this function, due to some of the parameters not have type annotations ;-)
