### PR TITLE
Improve error reporting when source cannot be minimized

### DIFF
--- a/pysource_minimize/__init__.py
+++ b/pysource_minimize/__init__.py
@@ -1,4 +1,5 @@
-from ._minimize import minimize, CouldNotMinimize
+from ._minimize import CouldNotMinimize
+from ._minimize import minimize
 from ._minimize_base import StopMinimization
 
 

--- a/pysource_minimize/__init__.py
+++ b/pysource_minimize/__init__.py
@@ -1,8 +1,8 @@
-from ._minimize import minimize
+from ._minimize import minimize, CouldNotMinimize
 from ._minimize_base import StopMinimization
 
 
-__all__ = ("minimize", "StopMinimization")
+__all__ = ("minimize", "CouldNotMinimize", "StopMinimization")
 
 
 version = "0.6.2"

--- a/pysource_minimize/_minimize.py
+++ b/pysource_minimize/_minimize.py
@@ -54,6 +54,10 @@ def minimize_ast(
     return current_ast
 
 
+class CouldNotMinimize(ValueError):
+    """Raised to indicate that the source code could not be minimized."""
+
+
 def minimize(
     source: str,
     checker: Callable[[str], bool],
@@ -87,7 +91,10 @@ def minimize(
         return checker(source)
 
     if not source_checker(original_ast):
-        raise ValueError("ast.unparse removes the error minimize can not help here")
+        raise CouldNotMinimize(
+            "Source code cannot be minimized: the error failed to reproduce "
+            "after roundtripping the source using `ast.parse()` and `ast.unparse()`"
+        )
 
     minimized_ast = minimize_ast(
         original_ast,


### PR DESCRIPTION
I ran into this `ValueError` while working on https://github.com/astral-sh/ruff/blob/main/scripts/fuzz-parser/fuzz.py, and found it slightly confusing at first. The issue we were running into was that a race condition (from running many fuzzing processes in parallel in a `ProcessPoolExecutor`) was meaning that our `contains_bug()` function was flaky -- so `pysource-codegen` would report that there was a bug, but then `pysource-minimize` wouldn't be able to repro the bug, causing the ValueError to be raised. But the exception message made me think that ruff's parser was erroring out because of some odd whitespace or other trivia that would be erased from the `ast.parse()`/`ast.unparse()` roundtrip, and that wasn't the case.

This PR attempts to improve the error message here slightly. It also adds a dedicated exception class, so that I can do `except CouldNotMinimize` [here](https://github.com/astral-sh/ruff/blob/d544199272d9d6e3acb18252717baf4a7233634c/scripts/fuzz-parser/fuzz.py#L91) instead of `except ValueError` (which feels not great, since a lot of things could raise `ValueError`; it's hard to know that the `ValueError` is coming from `pysource-minimize` specifically there :-)